### PR TITLE
Fixing rsocket-rpc dependency and examples to match readme

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ allprojects {
         maven {
             url  "https://dl.bintray.com/netifi/netifi-oss"
         }
+        maven {
+            url  "https://dl.bintray.com/rsocket-admin/RSocket"
+        }
     }
 
     license {

--- a/demos/springboot-demo/isvowel-service/src/main/java/io/netifi/proteus/demo/isvowel/service/DefaultIsVowelService.java
+++ b/demos/springboot-demo/isvowel-service/src/main/java/io/netifi/proteus/demo/isvowel/service/DefaultIsVowelService.java
@@ -24,6 +24,9 @@ import reactor.core.publisher.Mono;
 import java.util.HashSet;
 import java.util.Set;
 
+/**
+ * Service that receives a character and responds with whether or not that character is a vowel.
+ */
 @Component
 public class DefaultIsVowelService implements IsVowelService {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultIsVowelService.class);

--- a/demos/springboot-demo/vowelcount-idl/src/main/proto/vowelcount.proto
+++ b/demos/springboot-demo/vowelcount-idl/src/main/proto/vowelcount.proto
@@ -7,7 +7,7 @@ option java_outer_classname = "VowelCountServiceProto";
 option java_multiple_files = true;
 
 service VowelCountService {
-  rpc CountVowels (stream VowelCountRequest) returns (VowelCountResponse) {}
+  rpc CountVowels (stream VowelCountRequest) returns (stream VowelCountResponse) {}
 }
 
 message VowelCountRequest {


### PR DESCRIPTION
This addresses the following issues:

- Fixes the issue with the rsocket-rpc libraries being moved in bintray
- Fixes the code changes that were made to the example that prevented it from completing as it once did.
- Enhances the example project to better show the vowels being counted in realtime.

This also address Issue #9 