### PR TITLE
Add spring boot autoconfigure processor dependency

### DIFF
--- a/proteus-spring-boot-autoconfigure/build.gradle
+++ b/proteus-spring-boot-autoconfigure/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     compile 'io.micrometer:micrometer-core:1.0.6'
 
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+    annotationProcessor "org.springframework.boot:spring-boot-autoconfigure-processor"
 
     testCompile 'org.springframework.boot:spring-boot-starter-test'
     testCompile 'org.mockito:mockito-core'


### PR DESCRIPTION
This dependency generate metadata needed to help Spring Boot with the
startup time.