### PR TITLE
fixes client autowire when no bean definition scanned

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ allprojects {
     apply plugin: 'net.saliman.properties'
 
     ext {
-        proteusVersion = '1.6.0.BUILD-SNAPSHOT'
+        proteusVersion = '1.6.0-RC'
         protobufVersion = '3.6.1'
         rsocketRpcVersion = '0.2.12'
         springBootDependenciesVersion = '2.1.2.RELEASE'

--- a/proteus-spring-core/src/main/java/io/netifi/proteus/spring/core/annotation/ProteusClientStaticFactory.java
+++ b/proteus-spring-core/src/main/java/io/netifi/proteus/spring/core/annotation/ProteusClientStaticFactory.java
@@ -27,7 +27,10 @@ import io.rsocket.RSocket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.beans.factory.annotation.AnnotatedGenericBeanDefinition;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.beans.factory.support.AutowireCandidateQualifier;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.core.ResolvableType;
 import org.springframework.util.Assert;
@@ -133,6 +136,13 @@ public class ProteusClientStaticFactory {
 
             Object newInstance = beanFactory.initializeBean(toRegister, beanName);
             beanFactory.autowireBeanProperties(newInstance, AutowireCapableBeanFactory.AUTOWIRE_BY_NAME, true);
+            AnnotatedGenericBeanDefinition beanDefinition = new AnnotatedGenericBeanDefinition(clientClass);
+            AutowireCandidateQualifier qualifier = new AutowireCandidateQualifier(Qualifier.class);
+
+            qualifier.setAttribute("value", "client");
+            beanDefinition.addQualifier(qualifier);
+
+            beanFactory.registerBeanDefinition(beanName, beanDefinition);
             beanFactory.registerSingleton(beanName, newInstance);
 
             LOGGER.debug("Bean named '{}' created successfully.", beanName);


### PR DESCRIPTION
Bugfix for Proteus client annotated with `@Group` or `@Destination` annotations autowiring when they are not in the classpath scan and autowired more then one time